### PR TITLE
Extract more strings from Node Documentation Html Generator

### DIFF
--- a/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
+++ b/src/DocumentationBrowserViewExtension/NodeDocumentationHtmlGenerator.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Linq;
+using Dynamo.DocumentationBrowser.Properties;
 using Dynamo.ViewModels;
 
 namespace Dynamo.DocumentationBrowser
@@ -35,8 +36,8 @@ namespace Dynamo.DocumentationBrowser
         private static string CreateHeader(OpenNodeAnnotationEventArgs e)
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine(string.Format("<h1>{0}</h1>", e.Type));
-            sb.AppendLine(string.Format("<p><i>{0}</i></p>", e.MinimumQualifiedName));
+            sb.AppendLine($"<h1>{e.Type}</h1>");
+            sb.AppendLine($"<p><i>{e.MinimumQualifiedName}</i></p>");
             sb.AppendLine("<hr>");
 
             return sb.ToString();
@@ -45,35 +46,37 @@ namespace Dynamo.DocumentationBrowser
         private static string CreateNodeInfo(OpenNodeAnnotationEventArgs e)
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine("<h2>Node Info</h2>");
+            sb.AppendLine($"<h2>{Resources.NodeDocumentationNodeInfo}</h2>");
             sb.AppendLine("<table class=\"table--noborder\">");
             sb.AppendLine("<tr>");
-            sb.AppendLine(string.Format("<td>{0}</td>", "Node Type"));
-            sb.AppendLine(string.Format("<td>{0}</td>", e.Type));
+            sb.AppendLine($"<td>{Resources.NodeDocumentationNodeType}</td>");
+            sb.AppendLine($"<td>{e.Type}</td>");
             sb.AppendLine("</tr>");
             sb.AppendLine("<tr>");
-            sb.AppendLine(string.Format("<td>{0}</td>", "Description"));
-            sb.AppendLine(string.Format("<td>{0}</td>", Regex.Replace(e.Description, @"\r\n?|\n", "<br>")));
+            sb.AppendLine($"<td>{Resources.NodeDocumentationDescription}</td>");
+            sb.AppendLine($"<td>{Regex.Replace(e.Description, @"\r\n?|\n", "<br>")}</td>");
             sb.AppendLine("</tr>");
             sb.AppendLine("<tr>");
-            sb.AppendLine(string.Format("<td>{0}</td>", "Category"));
-            sb.AppendLine(string.Format("<td>{0}</td>", e.Category));
+            sb.AppendLine($"<td>{Resources.NodeDocumentationCategory}</td>");
+            sb.AppendLine($"<td>{e.Category}</td>");
             sb.AppendLine("</tr>");
             sb.AppendLine("<tr>");
-            sb.AppendLine(string.Format("<td>{0}</td>", "Inputs"));
+            sb.AppendLine($"<td>{Resources.NodeDocumentationInputs}</td>");
             sb.AppendLine("<td>");
             for (int i = 0; i < e.InputNames.Count(); i++)
             {
-                sb.AppendLine(string.Format("<li style=\"margin-bottom: 5px\"><b><u>{0}</u></b><br>{1}</li>", e.InputNames.ElementAt(i), Regex.Replace(e.InputDescriptions.ElementAt(i), @"\r\n?|\n", "<br>")));
+                sb.AppendLine(
+                    $"<li style=\"margin-bottom: 5px\"><b><u>{e.InputNames.ElementAt(i)}</u></b><br>{Regex.Replace(e.InputDescriptions.ElementAt(i), @"\r\n?|\n", "<br>")}</li>");
             }
             sb.AppendLine("</td>");
             sb.AppendLine("</tr>");
             sb.AppendLine("<tr>");
-            sb.AppendLine(string.Format("<td>{0}</td>", "Outputs"));
+            sb.AppendLine($"<td>{Resources.NodeDocumentationOutputs}</td>");
             sb.AppendLine("<td>");
             for (int i = 0; i < e.OutputNames.Count(); i++)
             {
-                sb.AppendLine(string.Format("<li style=\"margin-bottom: 5px\"><b><u>{0}</u></b><br>{1}</li>", e.OutputNames.ElementAt(i), Regex.Replace(e.OutputDescriptions.ElementAt(i), @"\r\n?|\n", "<br>")));
+                sb.AppendLine(
+                    $"<li style=\"margin-bottom: 5px\"><b><u>{e.OutputNames.ElementAt(i)}</u></b><br>{Regex.Replace(e.OutputDescriptions.ElementAt(i), @"\r\n?|\n", "<br>")}</li>");
             }
             sb.AppendLine("</td>");
             sb.AppendLine("</tr>");

--- a/src/DocumentationBrowserViewExtension/Properties/Resources.Designer.cs
+++ b/src/DocumentationBrowserViewExtension/Properties/Resources.Designer.cs
@@ -106,6 +106,60 @@ namespace Dynamo.DocumentationBrowser.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Category.
+        /// </summary>
+        public static string NodeDocumentationCategory {
+            get {
+                return ResourceManager.GetString("NodeDocumentationCategory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        public static string NodeDocumentationDescription {
+            get {
+                return ResourceManager.GetString("NodeDocumentationDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inputs.
+        /// </summary>
+        public static string NodeDocumentationInputs {
+            get {
+                return ResourceManager.GetString("NodeDocumentationInputs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Node Info.
+        /// </summary>
+        public static string NodeDocumentationNodeInfo {
+            get {
+                return ResourceManager.GetString("NodeDocumentationNodeInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Node Type.
+        /// </summary>
+        public static string NodeDocumentationNodeType {
+            get {
+                return ResourceManager.GetString("NodeDocumentationNodeType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Outputs.
+        /// </summary>
+        public static string NodeDocumentationOutputs {
+            get {
+                return ResourceManager.GetString("NodeDocumentationOutputs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Script tags detected in the help document have been removed..
         /// </summary>
         public static string ScriptTagsRemovalWarning {

--- a/src/DocumentationBrowserViewExtension/Properties/Resources.en-US.resx
+++ b/src/DocumentationBrowserViewExtension/Properties/Resources.en-US.resx
@@ -132,6 +132,30 @@
   <data name="MenuItemText" xml:space="preserve">
     <value>Show Documentation Browser</value>
   </data>
+  <data name="NodeDocumentationCategory" xml:space="preserve">
+    <value>Category</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationDescription" xml:space="preserve">
+    <value>Description</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationInputs" xml:space="preserve">
+    <value>Inputs</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationNodeInfo" xml:space="preserve">
+    <value>Node Info</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationNodeType" xml:space="preserve">
+    <value>Node Type</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationOutputs" xml:space="preserve">
+    <value>Outputs</value>
+    <comment>Header in Node Info table</comment>
+  </data>
   <data name="ScriptTagsRemovalWarning" xml:space="preserve">
     <value>Script tags detected in the help document have been removed.</value>
   </data>

--- a/src/DocumentationBrowserViewExtension/Properties/Resources.resx
+++ b/src/DocumentationBrowserViewExtension/Properties/Resources.resx
@@ -132,6 +132,30 @@
   <data name="MenuItemText" xml:space="preserve">
     <value>Show Documentation Browser</value>
   </data>
+  <data name="NodeDocumentationCategory" xml:space="preserve">
+    <value>Category</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationDescription" xml:space="preserve">
+    <value>Description</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationInputs" xml:space="preserve">
+    <value>Inputs</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationNodeInfo" xml:space="preserve">
+    <value>Node Info</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationNodeType" xml:space="preserve">
+    <value>Node Type</value>
+    <comment>Header in Node Info table</comment>
+  </data>
+  <data name="NodeDocumentationOutputs" xml:space="preserve">
+    <value>Outputs</value>
+    <comment>Header in Node Info table</comment>
+  </data>
   <data name="ScriptTagsRemovalWarning" xml:space="preserve">
     <value>Script tags detected in the help document have been removed.</value>
   </data>


### PR DESCRIPTION
### Purpose

Extract more strings from Node Documentation Html Generator

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@mjkkirschner 

### FYIs
