### PR TITLE
add new flag -g to compress gifs

### DIFF
--- a/src/Tools/NodeDocumentationMarkdownGenerator/Commands/FromDirectoryCommand.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/Commands/FromDirectoryCommand.cs
@@ -22,7 +22,7 @@ namespace NodeDocumentationMarkdownGenerator.Commands
                 fileInfos.AddRange(ScanFolderForCustomNodes(opts.InputFolderPath, searchOption));
             }
 
-            MarkdownHandler.CreateMdFilesFromFileNames(fileInfos, opts.OutputFolderPath, opts.Overwrite, opts.CompressImages, opts.DictionaryDirectory, opts.LayoutSpecPath);
+            MarkdownHandler.CreateMdFilesFromFileNames(fileInfos, opts.OutputFolderPath, opts.Overwrite, opts.CompressImages, opts.CompressGifs, opts.DictionaryDirectory, opts.LayoutSpecPath);
         }
 
         private static List<MdFileInfo> ScanFolderForCustomNodes(string inputFolderPath, SearchOption searchOption)

--- a/src/Tools/NodeDocumentationMarkdownGenerator/MarkdownHandler.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/MarkdownHandler.cs
@@ -21,11 +21,12 @@ namespace NodeDocumentationMarkdownGenerator
         /// <param name="outputDir">Folder path where files should be created</param>
         /// <param name="overWrite">if true, files in outputDir will be overwritten</param>
         /// <param name="compressImages">if true images matched from dictionary will be compressed (if possible)</param>
+        /// <param name="compressGifs">if true animated gifs matched from dictionary will be compressed (if possible)</param>
         /// <param name="dictionaryPath">path to dictionary json file</param>
         /// <param name="layoutSpec">path to layout spec json</param>
         internal static void CreateMdFilesFromFileNames(
             IEnumerable<MdFileInfo> fileInfos, string outputDir, bool overWrite, 
-            bool compressImages = false, string dictionaryPath = null, string layoutSpec = null)
+            bool compressImages = false, bool compressGifs = false, string dictionaryPath = null, string layoutSpec = null)
         {
             ImageOptimizer optimizer = null;
             LayoutSpecification spec = null;
@@ -84,7 +85,7 @@ namespace NodeDocumentationMarkdownGenerator
                     DynamoDictionaryEntry matchingEntry = GetMatchingDictionaryEntry(dictEntrys, info, spec);
                     if (matchingEntry != null)
                     {
-                        fileContent = GetContentFromDictionaryEntry(matchingEntry, examplesDirectory, optimizer, fileInfo);    
+                        fileContent = GetContentFromDictionaryEntry(matchingEntry, examplesDirectory, optimizer,compressGifs, fileInfo);    
                     }
                 }
 
@@ -131,7 +132,7 @@ namespace NodeDocumentationMarkdownGenerator
 
         private static string GetContentFromDictionaryEntry(
             DynamoDictionaryEntry entry, string examplesDirectory, 
-            ImageOptimizer optimizer, FileInfo fileInfo)
+            ImageOptimizer optimizer, bool compressGifs, FileInfo fileInfo)
         {
             var imgDir = new DirectoryInfo(Path.Combine(examplesDirectory, entry.FolderPath, "img"));
 
@@ -145,7 +146,7 @@ namespace NodeDocumentationMarkdownGenerator
             var imageFile = entry.ImageFile.FirstOrDefault();
             if (imgDir.Exists &&
                 imgDir.GetFiles($"{imageFile}.*").Length > 0 &&
-                !TrySaveImage(imgDir, imageFile, optimizer, fileInfo, out imageString))
+                !TrySaveImage(imgDir, imageFile, optimizer, compressGifs, fileInfo, out imageString))
             {
                 missingFields.Add("Image");
             }
@@ -169,7 +170,7 @@ namespace NodeDocumentationMarkdownGenerator
 
         private static bool TrySaveImage(
             DirectoryInfo imgDir, string imgName, 
-            ImageOptimizer optimizer, FileInfo fileInfo, 
+            ImageOptimizer optimizer,bool compressGifs, FileInfo fileInfo, 
             out string outputImagePath)
         {
             outputImagePath = string.Empty;
@@ -177,29 +178,55 @@ namespace NodeDocumentationMarkdownGenerator
 
             if (!imageFileInfo.Exists) return false;
 
+            
+
             try
             {
                 using (Image image = Image.FromFile(imageFileInfo.FullName))
                 using (MemoryStream m = new MemoryStream())
                 {
                     image.Save(m, image.RawFormat);
-
-                    if (optimizer != null)
+                    var oldSize = m.Length;
+                    var ext = imageFileInfo.Extension.ToLower();
+                    //the simple optimizer fails with animated gifs, or gifs that have already been semi optimized (different size frames)
+                    if (optimizer != null && ext != ".gif" )
                     {
                         m.Position = 0;
                         optimizer.Compress(m);
                     }
+                    //animated gif compression does not robustly with the optimizer.
+                    if (compressGifs && ext == ".gif")
+                    {
+                        using (MagickImageCollection images = new MagickImageCollection(imageFileInfo))
+                        {
+                            //I've disabled these optimization steps for now because they are extremely slow.
+                            //quantization is much faster and produces mostly very good results. (though not lossless)
 
+                            //images.Coalesce();
+                            //images.Optimize();
+                            //images.OptimizeTransparency();
+                            //reduce color bit depth from 8 to 5.
+                            images.Quantize(new QuantizeSettings() { Colors = 32768 });
+                            m.Position = 0;
+                            m.SetLength(0);
+                            images.Write(m);
+                        }
+                    }
+
+                    var newsize = m.Length;
+                    System.Diagnostics.Debug.WriteLine($"reduced {imageFileInfo.Name} from {oldSize} to {newsize} ~{ (int)(100.0 - (((float)newsize / (float)oldSize) * 100.0))}% reduction");
                     var img = Image.FromStream(m);
                     var fileName = $"{Path.GetFileNameWithoutExtension(fileInfo.FullName)}_img{imageFileInfo.Extension}";
                     var path = Path.Combine(fileInfo.Directory.FullName, fileName);
                     img.Save(path);
                     outputImagePath = $"![{imgName}](./{fileName.Replace(" ", "%20")})";
+                    
                     return true;
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Console.WriteLine(e);
                 return false;
             }
 

--- a/src/Tools/NodeDocumentationMarkdownGenerator/MarkdownHandler.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/MarkdownHandler.cs
@@ -194,7 +194,6 @@ namespace NodeDocumentationMarkdownGenerator
                         m.Position = 0;
                         optimizer.Compress(m);
                     }
-                    //animated gif compression does not robustly with the optimizer.
                     if (compressGifs && ext == ".gif")
                     {
                         using (MagickImageCollection images = new MagickImageCollection(imageFileInfo))

--- a/src/Tools/NodeDocumentationMarkdownGenerator/Program.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13,6 +14,8 @@ namespace NodeDocumentationMarkdownGenerator
         internal static IEnumerable<FileInfo> DynamoDirectoryAssemblyPaths;
         static void Main(string[] args)
         {
+            var sw = new Stopwatch();
+            sw.Start();
             Program.DynamoDirectoryAssemblyPaths = new DirectoryInfo(
                 Path.GetFullPath(
                     Path.Combine(
@@ -29,6 +32,10 @@ namespace NodeDocumentationMarkdownGenerator
                     (FromDirectoryOptions opts) => CommandHandler.HandleFromDirectory(opts),
                     (FromPackageOptions opts) => CommandHandler.HandleFromPackage(opts),
                     err => "1");
+            Console.WriteLine($"docs generation took {sw.Elapsed.TotalSeconds}");
+# if DEBUG
+            Console.ReadLine();
+#endif
         }
 
         private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)

--- a/src/Tools/NodeDocumentationMarkdownGenerator/Verbs/FromDirectoryOptions.cs
+++ b/src/Tools/NodeDocumentationMarkdownGenerator/Verbs/FromDirectoryOptions.cs
@@ -35,6 +35,9 @@ namespace NodeDocumentationMarkdownGenerator.Verbs
         [Option('s', "compress-images", HelpText = "When set, the tool will try to compress images from dictionary content", Required = false, Default = false)]
         public bool CompressImages { get; set; }
 
+        [Option('g', "compress-gifs", HelpText = "When set, the tool will try to compress gifs from dictionary content", Required = false, Default = false)]
+        public bool CompressGifs { get; set; }
+
         [Option('x', "layout-spec", HelpText = "Path to a LayoutSpecification json file", Required = false)]
         public string LayoutSpecPath { get; set; }
 


### PR DESCRIPTION
This PR fixes an issue where animated gifs were not optimized at all. There are a few issues.
* gifs/animated gifs are quite complex - if they have been optimized before using certain methods -they cannot be optimized again - for example, if they contain frames with different internal sizes. (an optimization technique)
it's possible to undo this and then optimize with image magick, but I found this to be too slow ~ 10 minutes for 40 gifs.
Instead I found that using quantization (color reduction to 32k colors) works very well, is quite fast, and produces results about 10% - 50% reduction per gif.

* running the tool on RevitNodes.dll and Revit dictionary takes 33 seconds before this change, and 99 seconds after this change - the folder is reduced from 44megs to 38 megs. (we don't have that many .gifs in the Revit dictionary content today, only 40.)

* because reducing the .gif's is still quite slow overall, and ⚠️ ❗   **not lossless** I added a separate flag for it, this is handy for quickly debugging other parts of the tool or avoiding the gif image changes.

* also now in debug mode leave console open until console.readline for easier log reading.

this is a pathologically bad example because it has a ton of colors used in the animation.

1Meg
![OverrideInView](https://user-images.githubusercontent.com/508936/129641082-58336644-b90d-4d20-bec4-3211943fea5c.gif)

900kB
![Revit Elements Element OverrideInView_img](https://user-images.githubusercontent.com/508936/129641079-68b54687-d7e2-400b-9dc8-a19b5ffd4ed1.gif)



